### PR TITLE
Força carregar layer com HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 	<!-- configuração de estilos (css) -->
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!-- include cartodb.js library -->
-	<script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+	<script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
 
 	<link rel="stylesheet" href="./css/lib/dc.min.css">
 	<!-- graphs styles -->

--- a/js/resolution.js
+++ b/js/resolution.js
@@ -534,7 +534,7 @@ function showThematicLayer(layer, tableName, theme, variable, variableDescr, cod
         style = HIGHLIGHT_STYLE;
         var sql = new cartodb.SQL({user: userStrTableGeo, format: 'geojson'});
         strQuery = "select cartodb_id, " + codcem + ", the_geom from " + strTableGeo;
-        console.log(strQuery)
+
         sql.execute(strQuery).done(function(geojson) {
             var features = geojson.features;
             polygons = {};

--- a/js/resolution.js
+++ b/js/resolution.js
@@ -414,14 +414,13 @@ function createLayerChoropletic(currentLayerData, theme, variable, variableDescr
             tableName = currentLayerData.tableNameWithoutBaseMap;
             codcem = currentLayerData.codcemWithBaseMap;
         }
-
         POLYGON_CODNAME = codcem;
 
         cartodb.createLayer(map, {
             user_name: cartoAccount,
             type: "cartodb",
             sublayers: []
-        })
+        }, { https: true })
             .addTo(map)
             .done(function (layer) {
                 // Clear all transport active layers
@@ -535,7 +534,7 @@ function showThematicLayer(layer, tableName, theme, variable, variableDescr, cod
         style = HIGHLIGHT_STYLE;
         var sql = new cartodb.SQL({user: userStrTableGeo, format: 'geojson'});
         strQuery = "select cartodb_id, " + codcem + ", the_geom from " + strTableGeo;
-
+        console.log(strQuery)
         sql.execute(strQuery).done(function(geojson) {
             var features = geojson.features;
             polygons = {};
@@ -1009,7 +1008,7 @@ cartodb.createLayer(map,{
     user_name: "cemdevops",
     type: "cartodb",
     sublayers: []
-})
+}, { https: true })
     .addTo(map)
     .done(function(layer){
         // set layer in order of overlap
@@ -1045,7 +1044,7 @@ function createPlacesLayer() {
         user_name: "cemdevops",
         type: "cartodb",
         sublayers: []
-    })
+    }, { https: true })
         .addTo(map) // add the layer to our map which already contains 0 sublayers
         .done(function (placesLayer) {
             var placesSublayer = null;
@@ -1108,7 +1107,7 @@ cartodb.createLayer(map,{
     user_name: "cemdevops",
     type: "cartodb",
     sublayers: []
-})
+}, { https: true })
     .addTo(map)
     .done(function(layer){
         // set layer in order of overlap
@@ -1131,7 +1130,7 @@ function showRMSP(zindex, polygonOpacity){
         user_name: "cemdevops",
         type: "cartodb",
         sublayers: []
-    })
+    }, { https: true })
         .addTo(map)
         .done(function(layer){
             // set layer in order of overlap


### PR DESCRIPTION
Adicionado o parâmetro para forçar HTTPS nas chamadas da função layer.createLayer() do carto.js